### PR TITLE
use SEO rewrited url instead of raw url

### DIFF
--- a/cartridges/int_queueit_sfra/cartridge/scripts/httpContextProvider.js
+++ b/cartridges/int_queueit_sfra/cartridge/scripts/httpContextProvider.js
@@ -12,7 +12,12 @@ exports.httpContextProvider = function() {
         getHttpRequest: function() {
             return {
                 getAbsoluteUri: function() { 
-                    return request.httpURL; 
+                    const protocol = this.getHeader('x-forwarded-proto') || this.getHeader('x-is-server_port_secure') === "1" ? 'https' : 'http';
+					let url = protocol  + '://' + this.getHeader('x-is-host') + this.getHeader('x-is-path_translated');
+					if (request.httpQueryString) {
+						url = url + '?' + request.httpQueryString;
+					}
+					return url;
                 },
                 getUserAgent: function() { 
                 	 request.httpUserAgent;
@@ -33,7 +38,7 @@ exports.httpContextProvider = function() {
         		getCookieValue : function (cookieKey)
         		{
         			var cookies = request.getHttpCookies();
-					
+
         			if (cookieKey in cookies)
         			{
         				var cookie =cookies[cookieKey]; 


### PR DESCRIPTION
When getting url, you take non rewrited url instead of SEO url.

When you return from queue page url is not rewrited.