### PR TITLE
fix concatenation issue that provide CUSTOMERIDnull string

### DIFF
--- a/cartridges/int_queueit_sfra/cartridge/scripts/request.js
+++ b/cartridges/int_queueit_sfra/cartridge/scripts/request.js
@@ -7,9 +7,10 @@ exports.onRequest = function() {
 	
 	if (queueItConfigs) {
 		// NOTE: probably want this to be inclusionary vs exclusionary: only do this logic if 
-		// page show / category show / add to cart Request Prefilter
-		var configs = configs =  'queueItCustomerId' in sitePrefs.getCustom() && sitePrefs.getCustom()["queueItCustomerId"] ? sitePrefs.getCustom()["queueItCustomerId"] : null;
-		configs += '|' + 'queueItSecretKey' in sitePrefs.getCustom() && sitePrefs.getCustom()["queueItSecretKey"] ? sitePrefs.getCustom()["queueItSecretKey"] : null;
+        // page show / category show / add to cart Request Prefilter
+        var configs = configs =  'queueItCustomerId' in sitePrefs.getCustom() && sitePrefs.getCustom()["queueItCustomerId"] ? sitePrefs.getCustom()["queueItCustomerId"] : null;
+        configs += '|';
+        configs += 'queueItSecretKey' in sitePrefs.getCustom() && sitePrefs.getCustom()["queueItSecretKey"] ? sitePrefs.getCustom()["queueItSecretKey"] : null;
 		
 		if (!(request.httpURL.toString().indexOf('__Analytics') >= 0)){
 			require('~/cartridge/scripts/QueueIt.js').Start(configs);


### PR DESCRIPTION
Concatenation issue when executed in SFCC context. 
config string is not queueItCustomerId|queueItSecretKey but queueItCustomerIdnull

